### PR TITLE
Refactor: Lastpass Service, Add Tests, Apply Formatting & Fix Folder Retrieval

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+insert_final_newline = true
+end_of_line = lf
+charset = utf-8
+indent_size = 4
+indent_style = space
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{htm,html,js,ts,tsx,css,sass,scss,less,svg,vue,json,yml,yaml}]
+indent_size = 2
+
+
+[{*.go,go.mod,go.sum,Makefile}]
+indent_style = tab
+tab_width = 4
+max_line_length = 0

--- a/src/cmd/folders.go
+++ b/src/cmd/folders.go
@@ -7,42 +7,40 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-    foldersCmd = &cobra.Command{
-        Use:          "folders",
-        Short:        "list folders",
-        SilenceUsage: true,
-        Args: cobra.ExactArgs(1),
-        Run: func(cmd *cobra.Command, args []string) {
-            ls, err := lastpass.NewLastpassService("lpass")
-            if err != nil {
-                wf.FatalError(err)
-            }
+var foldersCmd = &cobra.Command{
+	Use:          "folders",
+	Short:        "list folders",
+	SilenceUsage: true,
+	Args:         cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		ls, err := lastpass.NewLastpassService("lpass")
+		if err != nil {
+			wf.FatalError(err)
+		}
 
-            folders, err := ls.GetFolders()
-            if err != nil {
-                wf.FatalError(err)
-            }
+		folders, err := ls.GetFolders()
+		if err != nil {
+			wf.FatalError(err)
+		}
 
-            wf.NewItem("Select folder").
-                Match("*").
-                Subtitle("Type to search").
-                Valid(false)
+		wf.NewItem("Select folder").
+			Match("*").
+			Subtitle("Type to search").
+			Valid(false)
 
-            for _, f := range folders {
-                wf.NewItem(f.Name).
-                    UID(f.Name).
-                    Icon(util.IconFolder).
-                    Var("folder", f.Name).
-                    Valid(true)
-            }
+		for _, f := range folders {
+			wf.NewItem(f.Name).
+				UID(f.Name).
+				Icon(util.IconFolder).
+				Var("folder", f.Name).
+				Valid(true)
+		}
 
-            wf.Filter(args[0])
-            alfredutils.HandleFeedback(wf)
-        },
-    }
-)
+		wf.Filter(args[0])
+		alfredutils.HandleFeedback(wf)
+	},
+}
 
 func init() {
-    rootCmd.AddCommand(foldersCmd)
+	rootCmd.AddCommand(foldersCmd)
 }

--- a/src/cmd/folders.go
+++ b/src/cmd/folders.go
@@ -12,8 +12,8 @@ var foldersCmd = &cobra.Command{
 	Short:        "list folders",
 	SilenceUsage: true,
 	Args:         cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		ls, err := lastpass.NewLastpassService("lpass")
+	Run: func(_ *cobra.Command, args []string) {
+		ls, err := lastpass.NewService("lpass")
 		if err != nil {
 			wf.FatalError(err)
 		}

--- a/src/cmd/generate.go
+++ b/src/cmd/generate.go
@@ -10,44 +10,44 @@ import (
 )
 
 var (
-    lengthFlag int
-    generateCmd = &cobra.Command{
-        Use:          "generate",
-        Short:        "generate new password",
-        SilenceUsage: true,
-        Run: func(cmd *cobra.Command, args []string) {
-            pws, err := util.GeneratePassword(lengthFlag, true, cfg.AllowedSymbols)
-            if err != nil {
-                wf.FatalError(err)
-            }
-            pwn, err := util.GeneratePassword(lengthFlag, false, "")
-            if err != nil {
-                wf.FatalError(err)
-            }
+	lengthFlag  int
+	generateCmd = &cobra.Command{
+		Use:          "generate",
+		Short:        "generate new password",
+		SilenceUsage: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			pws, err := util.GeneratePassword(lengthFlag, true, cfg.AllowedSymbols)
+			if err != nil {
+				wf.FatalError(err)
+			}
+			pwn, err := util.GeneratePassword(lengthFlag, false, "")
+			if err != nil {
+				wf.FatalError(err)
+			}
 
-            sub := fmt.Sprintf("⏎ to copy to clipboard  •  ⌘⏎ to add to LastPass  •  Length: %d", lengthFlag)
-            wf.NewItem(pws).
-                Subtitle(sub).
-                Var("password", pws).
-                Arg("copy").
-                Valid(true).
-                NewModifier(aw.ModCmd).
-                Arg("add")
+			sub := fmt.Sprintf("⏎ to copy to clipboard  •  ⌘⏎ to add to LastPass  •  Length: %d", lengthFlag)
+			wf.NewItem(pws).
+				Subtitle(sub).
+				Var("password", pws).
+				Arg("copy").
+				Valid(true).
+				NewModifier(aw.ModCmd).
+				Arg("add")
 
-            wf.NewItem(pwn).
-                Subtitle(sub+"  •  No symbols").
-                Var("password", pwn).
-                Arg("copy").
-                Valid(true).
-                NewModifier(aw.ModCmd).
-                Arg("add")
+			wf.NewItem(pwn).
+				Subtitle(sub+"  •  No symbols").
+				Var("password", pwn).
+				Arg("copy").
+				Valid(true).
+				NewModifier(aw.ModCmd).
+				Arg("add")
 
-            alfredutils.HandleFeedback(wf)
-        },
-    }
+			alfredutils.HandleFeedback(wf)
+		},
+	}
 )
 
 func init() {
-    generateCmd.Flags().IntVarP(&lengthFlag, "length", "l", 32, "length of password to generate")
-    rootCmd.AddCommand(generateCmd)
+	generateCmd.Flags().IntVarP(&lengthFlag, "length", "l", 32, "length of password to generate")
+	rootCmd.AddCommand(generateCmd)
 }

--- a/src/cmd/generate.go
+++ b/src/cmd/generate.go
@@ -9,13 +9,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const passwordLengthDefault = 32
+
 var (
 	lengthFlag  int
 	generateCmd = &cobra.Command{
 		Use:          "generate",
 		Short:        "generate new password",
 		SilenceUsage: true,
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			pws, err := util.GeneratePassword(lengthFlag, true, cfg.AllowedSymbols)
 			if err != nil {
 				wf.FatalError(err)
@@ -48,6 +50,6 @@ var (
 )
 
 func init() {
-	generateCmd.Flags().IntVarP(&lengthFlag, "length", "l", 32, "length of password to generate")
+	generateCmd.Flags().IntVarP(&lengthFlag, "length", "l", passwordLengthDefault, "length of password to generate")
 	rootCmd.AddCommand(generateCmd)
 }

--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -15,7 +15,7 @@ var (
 		Short:        "list entries",
 		SilenceUsage: false,
 		Args:         cobra.RangeArgs(0, 1),
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			var query string
 			if len(args) > 0 {
 				query = args[0]

--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -1,77 +1,77 @@
 package cmd
 
 import (
-    "fmt"
+	"fmt"
 
-    aw "github.com/deanishe/awgo"
-    "github.com/rwilgaard/go-alfredutils/alfredutils"
-    "github.com/spf13/cobra"
+	aw "github.com/deanishe/awgo"
+	"github.com/rwilgaard/go-alfredutils/alfredutils"
+	"github.com/spf13/cobra"
 )
 
 var (
-    foldersFlag []string
-    listCmd     = &cobra.Command{
-        Use:          "list",
-        Short:        "list entries",
-        SilenceUsage: false,
-        Args:         cobra.RangeArgs(0, 1),
-        Run: func(cmd *cobra.Command, args []string) {
-            var query string
-            if len(args) > 0 {
-                query = args[0]
-            }
+	foldersFlag []string
+	listCmd     = &cobra.Command{
+		Use:          "list",
+		Short:        "list entries",
+		SilenceUsage: false,
+		Args:         cobra.RangeArgs(0, 1),
+		Run: func(cmd *cobra.Command, args []string) {
+			var query string
+			if len(args) > 0 {
+				query = args[0]
+			}
 
-            entries, err := ls.GetEntries(query, foldersFlag, cfg.FuzzySearch)
-            if err != nil {
-                wf.FatalError(err)
-            }
+			entries, err := ls.GetEntries(query, foldersFlag, cfg.FuzzySearch)
+			if err != nil {
+				wf.FatalError(err)
+			}
 
-            for _, e := range entries {
-                it := wf.NewItem(e.Name).
-                    Subtitle(fmt.Sprintf("%s  •  ID: %s", e.Folder, e.ID)).
-                    Match(fmt.Sprintf("%s %s %s %s", e.ID, e.Folder, e.Name, e.URL)).
-                    UID(e.ID).
-                    Var("item_id", e.ID).
-                    Var("item_name", e.Name).
-                    Var("item_url", e.URL).
-                    Var("item_folder", e.Folder).
-                    Var("query", query).
-                    Var("action", cfg.ModifierReturn).
-                    Valid(ls.CheckValidity(e, cfg.ModifierReturn))
+			for _, e := range entries {
+				it := wf.NewItem(e.Name).
+					Subtitle(fmt.Sprintf("%s  •  ID: %s", e.Folder, e.ID)).
+					Match(fmt.Sprintf("%s %s %s %s", e.ID, e.Folder, e.Name, e.URL)).
+					UID(e.ID).
+					Var("item_id", e.ID).
+					Var("item_name", e.Name).
+					Var("item_url", e.URL).
+					Var("item_folder", e.Folder).
+					Var("query", query).
+					Var("action", cfg.ModifierReturn).
+					Valid(ls.CheckValidity(e, cfg.ModifierReturn))
 
-                if ls.CheckValidity(e, cfg.ModifierCtrl) {
-                    it.NewModifier(aw.ModCtrl).
-                        Subtitle(cfg.ModifierCtrl).
-                        Var("action", cfg.ModifierCtrl).
-                        Valid(true)
-                }
+				if ls.CheckValidity(e, cfg.ModifierCtrl) {
+					it.NewModifier(aw.ModCtrl).
+						Subtitle(cfg.ModifierCtrl).
+						Var("action", cfg.ModifierCtrl).
+						Valid(true)
+				}
 
-                if ls.CheckValidity(e, cfg.ModifierOpt) {
-                    it.NewModifier(aw.ModOpt).
-                        Subtitle(cfg.ModifierOpt).
-                        Var("action", cfg.ModifierOpt).
-                        Valid(true)
-                }
+				if ls.CheckValidity(e, cfg.ModifierOpt) {
+					it.NewModifier(aw.ModOpt).
+						Subtitle(cfg.ModifierOpt).
+						Var("action", cfg.ModifierOpt).
+						Valid(true)
+				}
 
-                if ls.CheckValidity(e, cfg.ModifierCmd) {
-                    it.NewModifier(aw.ModCmd).
-                        Subtitle(cfg.ModifierCmd).
-                        Var("action", cfg.ModifierCmd).
-                        Valid(true)
-                }
-            }
+				if ls.CheckValidity(e, cfg.ModifierCmd) {
+					it.NewModifier(aw.ModCmd).
+						Subtitle(cfg.ModifierCmd).
+						Var("action", cfg.ModifierCmd).
+						Valid(true)
+				}
+			}
 
-            if cfg.FuzzySearch && len(query) > 0 {
-                wf.Filter(query)
-            }
+			if cfg.FuzzySearch && len(query) > 0 {
+				wf.Filter(query)
+			}
 
-            alfredutils.HandleFeedback(wf)
-        },
-    }
+			alfredutils.HandleFeedback(wf)
+		},
+	}
 )
 
 func init() {
-    listCmd.Flags().StringSliceVarP(&foldersFlag, "folders", "f", []string{}, "Filter entries by folders")
+	listCmd.Flags().StringSliceVarP(&foldersFlag, "folders", "f", []string{}, "Filter entries by folders")
 
-    rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(listCmd)
 }

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -19,12 +19,13 @@ type workflowConfig struct {
 }
 
 const (
-	repo = "rwilgaard/alfred-lastpass-search"
+	repo       = "rwilgaard/alfred-lastpass-search"
+	maxResults = 25
 )
 
 var (
 	wf      *aw.Workflow
-	ls      *lastpass.LastpassService
+	ls      *lastpass.Service
 	cfg     = &workflowConfig{}
 	rootCmd = &cobra.Command{
 		Use:   "lastpass-alfred",
@@ -46,7 +47,7 @@ func run() {
 	}
 
 	var err error
-	ls, err = lastpass.NewLastpassService("lpass")
+	ls, err = lastpass.NewService("lpass")
 	if err != nil {
 		wf.FatalError(err)
 	}
@@ -70,7 +71,7 @@ func run() {
 
 func init() {
 	wf = aw.New(
-		aw.MaxResults(25),
+		aw.MaxResults(maxResults),
 		update.GitHub(repo),
 		aw.SuppressUIDs(true),
 	)

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -1,77 +1,77 @@
 package cmd
 
 import (
-    aw "github.com/deanishe/awgo"
-    "github.com/deanishe/awgo/update"
-    "github.com/rwilgaard/alfred-lastpass-search/src/pkg/lastpass"
-    "github.com/rwilgaard/go-alfredutils/alfredutils"
-    "github.com/spf13/cobra"
+	aw "github.com/deanishe/awgo"
+	"github.com/deanishe/awgo/update"
+	"github.com/rwilgaard/alfred-lastpass-search/src/pkg/lastpass"
+	"github.com/rwilgaard/go-alfredutils/alfredutils"
+	"github.com/spf13/cobra"
 )
 
 type workflowConfig struct {
-    ModifierReturn      string `env:"modifier_return"`
-    ModifierCmd         string `env:"modifier_cmd"`
-    ModifierOpt         string `env:"modifier_opt"`
-    ModifierCtrl        string `env:"modifier_ctrl"`
-    AllowedSymbols      string `env:"allowed_symbols"`
-    FuzzySearch         bool   `env:"fuzzy_search"`
-    IntelligentOrdering bool   `env:"intelligent_ordering"`
+	ModifierReturn      string `env:"modifier_return"`
+	ModifierCmd         string `env:"modifier_cmd"`
+	ModifierOpt         string `env:"modifier_opt"`
+	ModifierCtrl        string `env:"modifier_ctrl"`
+	AllowedSymbols      string `env:"allowed_symbols"`
+	FuzzySearch         bool   `env:"fuzzy_search"`
+	IntelligentOrdering bool   `env:"intelligent_ordering"`
 }
 
 const (
-    repo = "rwilgaard/alfred-lastpass-search"
+	repo = "rwilgaard/alfred-lastpass-search"
 )
 
 var (
-    wf      *aw.Workflow
-    ls      *lastpass.LastpassService
-    cfg     = &workflowConfig{}
-    rootCmd = &cobra.Command{
-        Use:   "lastpass-alfred",
-        Short: "lastpass-alfred is a CLI to be used by Alfred for searching in your Lastpass Vault",
-    }
+	wf      *aw.Workflow
+	ls      *lastpass.LastpassService
+	cfg     = &workflowConfig{}
+	rootCmd = &cobra.Command{
+		Use:   "lastpass-alfred",
+		Short: "lastpass-alfred is a CLI to be used by Alfred for searching in your Lastpass Vault",
+	}
 )
 
 func Execute() {
-    wf.Run(run)
+	wf.Run(run)
 }
 
 func run() {
-    if err := alfredutils.InitWorkflow(wf, cfg); err != nil {
-        wf.FatalError(err)
-    }
+	if err := alfredutils.InitWorkflow(wf, cfg); err != nil {
+		wf.FatalError(err)
+	}
 
-    if err := alfredutils.CheckForUpdates(wf); err != nil {
-        wf.FatalError(err)
-    }
+	if err := alfredutils.CheckForUpdates(wf); err != nil {
+		wf.FatalError(err)
+	}
 
-    var err error
-    ls, err = lastpass.NewLastpassService("lpass")
-    if err != nil {
-        wf.FatalError(err)
-    }
+	var err error
+	ls, err = lastpass.NewLastpassService("lpass")
+	if err != nil {
+		wf.FatalError(err)
+	}
 
-    if !ls.IsLoggedIn() {
-        wf.NewItem("You're not logged in to Lastpass.").
-            Subtitle("Press ⏎ to login.").
-            Arg("auth").
-            Valid(true)
-        alfredutils.HandleFeedback(wf)
-    }
+	if !ls.IsLoggedIn() {
+		wf.NewItem("You're not logged in to Lastpass.").
+			Subtitle("Press ⏎ to login.").
+			Arg("auth").
+			Valid(true)
+		alfredutils.HandleFeedback(wf)
+	}
 
-    if cfg.IntelligentOrdering {
-        wf.Configure(aw.SuppressUIDs(false))
-    }
+	if cfg.IntelligentOrdering {
+		wf.Configure(aw.SuppressUIDs(false))
+	}
 
-    if err := rootCmd.Execute(); err != nil {
-        wf.FatalError(err)
-    }
+	if err := rootCmd.Execute(); err != nil {
+		wf.FatalError(err)
+	}
 }
 
 func init() {
-    wf = aw.New(
-        aw.MaxResults(25),
-        update.GitHub(repo),
-        aw.SuppressUIDs(true),
-    )
+	wf = aw.New(
+		aw.MaxResults(25),
+		update.GitHub(repo),
+		aw.SuppressUIDs(true),
+	)
 }

--- a/src/cmd/show.go
+++ b/src/cmd/show.go
@@ -16,7 +16,7 @@ var showCmd = &cobra.Command{
 	Short:        "show entry details",
 	SilenceUsage: true,
 	Args:         cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		itemID := args[0]
 
 		keys, details, err := ls.GetDetails(itemID)

--- a/src/cmd/show.go
+++ b/src/cmd/show.go
@@ -11,98 +11,96 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-    showCmd = &cobra.Command{
-        Use:          "show",
-        Short:        "show entry details",
-        SilenceUsage: true,
-        Args:         cobra.ExactArgs(1),
-        RunE: func(cmd *cobra.Command, args []string) error {
-            itemID := args[0]
+var showCmd = &cobra.Command{
+	Use:          "show",
+	Short:        "show entry details",
+	SilenceUsage: true,
+	Args:         cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		itemID := args[0]
 
-            keys, details, err := ls.GetDetails(itemID)
-            if err != nil {
-                wf.FatalError(err)
-            }
+		keys, details, err := ls.GetDetails(itemID)
+		if err != nil {
+			wf.FatalError(err)
+		}
 
-            excluded := []string{
-                "id", "name", "fullname", "last_modified_gmt",
-                "last_touch", "extra_fields", "folder", "notetype",
-                "language", "bit strength", "format", "date",
-            }
+		excluded := []string{
+			"id", "name", "fullname", "last_modified_gmt",
+			"last_touch", "extra_fields", "folder", "notetype",
+			"language", "bit strength", "format", "date",
+		}
 
-            redacted := []string{
-                "password", "passphrase", "private key",
-                "license key", "rootkey", "unsealkey",
-            }
+		redacted := []string{
+			"password", "passphrase", "private key",
+			"license key", "rootkey", "unsealkey",
+		}
 
-            fullname := fmt.Sprintf("%s/%s", os.Getenv("item_folder"), os.Getenv("item_name"))
+		fullname := fmt.Sprintf("%s/%s", os.Getenv("item_folder"), os.Getenv("item_name"))
 
-            wf.NewItem("Go back").
-                Icon(util.IconBack).
-                Arg("go_back").
-                Valid(true)
+		wf.NewItem("Go back").
+			Icon(util.IconBack).
+			Arg("go_back").
+			Valid(true)
 
-            wf.NewItem("Name").
-                Icon(util.GetIcon("name")).
-                Subtitle(fullname).
-                Arg(fullname).
-                Var("sensitive", "false").
-                Valid(true)
+		wf.NewItem("Name").
+			Icon(util.GetIcon("name")).
+			Subtitle(fullname).
+			Arg(fullname).
+			Var("sensitive", "false").
+			Valid(true)
 
-            for _, key := range keys {
-                value := details[key]
-                if slices.Contains(excluded, strings.ToLower(key)) {
-                    continue
-                }
-                if value == "" {
-                    continue
-                }
-                sub := value
-                sensitive := "false"
-                if slices.Contains(redacted, strings.ToLower(key)) {
-                    sub = strings.Repeat("•", 32)
-                    sensitive = "true"
-                }
-                if key == "Notes" {
-                    wf.NewItem(key).
-                        Icon(util.GetIcon(key)).
-                        Subtitle("Press ⏎ to show notes").
-                        Arg("notes").
-                        Var("sensitive", sensitive).
-                        Valid(true)
-                    continue
-                }
-                wf.NewItem(key).
-                    Icon(util.GetIcon(key)).
-                    Subtitle(sub).
-                    Arg(value).
-                    Var("sensitive", sensitive).
-                    Var("field", key).
-                    Valid(true)
-            }
+		for _, key := range keys {
+			value := details[key]
+			if slices.Contains(excluded, strings.ToLower(key)) {
+				continue
+			}
+			if value == "" {
+				continue
+			}
+			sub := value
+			sensitive := "false"
+			if slices.Contains(redacted, strings.ToLower(key)) {
+				sub = strings.Repeat("•", 32)
+				sensitive = "true"
+			}
+			if key == "Notes" {
+				wf.NewItem(key).
+					Icon(util.GetIcon(key)).
+					Subtitle("Press ⏎ to show notes").
+					Arg("notes").
+					Var("sensitive", sensitive).
+					Valid(true)
+				continue
+			}
+			wf.NewItem(key).
+				Icon(util.GetIcon(key)).
+				Subtitle(sub).
+				Arg(value).
+				Var("sensitive", sensitive).
+				Var("field", key).
+				Valid(true)
+		}
 
-            wf.NewItem("Edit entry").
-                Icon(util.IconEdit).
-                Arg("edit").
-                Valid(true)
+		wf.NewItem("Edit entry").
+			Icon(util.IconEdit).
+			Arg("edit").
+			Valid(true)
 
-            deleteMsg := fmt.Sprintf(`Are you sure you want to delete this entry?
+		deleteMsg := fmt.Sprintf(`Are you sure you want to delete this entry?
 Name: %s
 ID: %s`, fullname, itemID)
 
-            wf.NewItem("Delete entry").
-                Icon(util.IconDelete).
-                Arg("delete").
-                Var("msg", deleteMsg).
-                Valid(true)
+		wf.NewItem("Delete entry").
+			Icon(util.IconDelete).
+			Arg("delete").
+			Var("msg", deleteMsg).
+			Valid(true)
 
-            alfredutils.HandleFeedback(wf)
-            return nil
-        },
-    }
-)
+		alfredutils.HandleFeedback(wf)
+		return nil
+	},
+}
 
 func init() {
-    rootCmd.AddCommand(showCmd)
+	rootCmd.AddCommand(showCmd)
 }

--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -7,22 +7,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-    updateCmd = &cobra.Command{
-        Use:          "update",
-        Short:        "check for updates",
-        SilenceUsage: true,
-        RunE: func(cmd *cobra.Command, args []string) error {
-            wf.Configure(aw.TextErrors(true))
-            log.Println("Checking for updates...")
-            if err := wf.CheckForUpdate(); err != nil {
-                return err
-            }
-            return nil
-        },
-    }
-)
+var updateCmd = &cobra.Command{
+	Use:          "update",
+	Short:        "check for updates",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		wf.Configure(aw.TextErrors(true))
+		log.Println("Checking for updates...")
+		if err := wf.CheckForUpdate(); err != nil {
+			return err
+		}
+		return nil
+	},
+}
 
 func init() {
-    rootCmd.AddCommand(updateCmd)
+	rootCmd.AddCommand(updateCmd)
 }

--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -11,13 +11,10 @@ var updateCmd = &cobra.Command{
 	Use:          "update",
 	Short:        "check for updates",
 	SilenceUsage: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		wf.Configure(aw.TextErrors(true))
 		log.Println("Checking for updates...")
-		if err := wf.CheckForUpdate(); err != nil {
-			return err
-		}
-		return nil
+		return wf.CheckForUpdate()
 	},
 }
 

--- a/src/pkg/lastpass/lastpass.go
+++ b/src/pkg/lastpass/lastpass.go
@@ -1,161 +1,204 @@
 package lastpass
 
 import (
-    "errors"
-    "fmt"
-    "os/exec"
-    "regexp"
-    "strings"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
 
 	"github.com/rwilgaard/alfred-lastpass-search/src/pkg/util"
 )
 
+// LastpassService handles interactions with the LastPass CLI.
 type LastpassService struct {
-    BinPath string
+	BinPath     string
+	ExecCommand func(name string, arg ...string) *exec.Cmd
 }
 
 type LastpassFolder struct {
-    Name string
+	Name string
 }
 
 type LastpassEntry struct {
-    ID       string
-    Name     string
-    Folder   string
-    URL      string
-    Username string
-    Password string
+	ID       string
+	Name     string
+	Folder   string
+	URL      string
+	Username string
+	Password string
 }
 
+// NewLastpassService creates a new LastpassService.
 func NewLastpassService(binPath string) (*LastpassService, error) {
-    if len(binPath) == 0 {
-        return nil, errors.New("binPath is empty")
-    }
+	if len(binPath) == 0 {
+		return nil, errors.New("binPath is empty")
+	}
 
-    svc := &LastpassService{
-        BinPath: binPath,
-    }
+	svc := &LastpassService{
+		BinPath:     binPath,
+		ExecCommand: exec.Command, // Default to the real exec.Command
+	}
 
-    return svc, nil
+	return svc, nil
 }
 
+// IsLoggedIn checks if the user is logged into LastPass.
 func (ls *LastpassService) IsLoggedIn() bool {
-    cmd := exec.Command(ls.BinPath, "status", "--quiet")
-    if err := cmd.Run(); err != nil {
-        return false
-    }
-    return true
+	cmd := ls.ExecCommand(ls.BinPath, "status", "--quiet")
+	err := cmd.Run()
+
+	return err == nil
 }
 
+// GetFolders retrieves all LastPass folder names.
 func (ls *LastpassService) GetFolders() ([]LastpassFolder, error) {
-    cmd := ls.BinPath + " ls --format %aN,%al --sync=no | grep ',http://group$' | cut -d, -f1 | sort -u"
-    out, err := exec.Command("bash", "-c", cmd).Output()
-    if err != nil {
-        return nil, err
-    }
+	cmdString := ls.BinPath + ` ls --format="%/as%/ag" --sync=no | sort -u`
+	cmd := ls.ExecCommand("bash", "-c", cmdString)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("error running command to get folders: %w", err)
+	}
 
-    var folders []LastpassFolder
-    for _, folder := range strings.Split(string(out), "\n") {
-        lf := LastpassFolder{
-            Name: folder,
-        }
-        folders = append(folders, lf)
-    }
+	var folders []LastpassFolder
+	folderOutput := strings.TrimSuffix(string(out), "\n")
+	if folderOutput == "" {
+		return []LastpassFolder{}, nil
+	}
+	for _, folderName := range strings.Split(folderOutput, "\n") {
+		if folderName != "" { // Ensure we don't add empty folder names
+			lf := LastpassFolder{
+				Name: folderName,
+			}
+			folders = append(folders, lf)
+		}
+	}
 
-    return folders, nil
+	return folders, nil
 }
 
+// GetEntries retrieves LastPass entries, optionally filtered by query and folders.
 func (ls *LastpassService) GetEntries(query string, folders []string, fuzzy bool) ([]LastpassEntry, error) {
-    var output string
-    if len(folders) == 0 {
-        folders = append(folders, "")
-    }
+	var outputBuilder strings.Builder
 
-    for _, folder := range folders {
-        cmd := exec.Command(ls.BinPath, "ls", "--format", "%aN [id: %ai] [url: %al] [username: %au] %ap", "--sync=no", folder)
-        out, err := cmd.Output()
-        if err != nil {
-            return nil, fmt.Errorf("Error running lpass ls: %s", err)
-        }
+	if len(folders) == 0 {
+		folders = []string{""}
+	}
 
-        output += string(out)
-    }
+	for _, folder := range folders {
+		cmd := ls.ExecCommand(ls.BinPath, "ls", "--format", "%aN [id: %ai] [url: %al] [username: %au] %ap", "--sync=no", folder)
+		out, err := cmd.Output()
+		if err != nil {
+			return nil, fmt.Errorf("error running lpass ls for folder '%s': %w", folder, err)
+		}
+		outputBuilder.Write(out)
+		if len(out) > 0 && out[len(out)-1] != '\n' {
+			outputBuilder.WriteByte('\n')
+		}
+	}
 
-    idRegex := regexp.MustCompile(`\[id: ([0-9]+)\]`)
-    urlRegex := regexp.MustCompile(`\[url: (.+?)\]`)
-    nameRegex := regexp.MustCompile(`^.*?\/(.*?)\s\[`)
-    folderRegex := regexp.MustCompile(`^(.*?)\/`)
-    usernameRegex := regexp.MustCompile(`\[username: (.+?)\]`)
-    passwordRegex := regexp.MustCompile(`.*\] (.*)$`)
+	fullOutput := outputBuilder.String()
 
-    var entries []LastpassEntry
-    for _, l := range strings.Split(string(output), "\n") {
-        id := util.RegexSearch(idRegex, l)
-        name := util.RegexSearch(nameRegex, l)
-        folder := util.RegexSearch(folderRegex, l)
-        url := util.RegexSearch(urlRegex, l)
-        username := util.RegexSearch(usernameRegex, l)
-        password := util.RegexSearch(passwordRegex, l)
-        e := fmt.Sprintf("%s %s %s %s %s", id, name, folder, url, username)
-        if id == "" {
-            continue
-        }
-        if url == "http://group" {
-            continue
-        }
-        if !util.HasAll(strings.ToLower(e), strings.Split(strings.ToLower(query), " ")) && !fuzzy {
-            continue
-        }
-        entries = append(entries, LastpassEntry{
-            ID:       id,
-            Name:     name,
-            Folder:   folder,
-            URL:      url,
-            Username: username,
-            Password: password,
-        })
-    }
-    return entries, nil
+	idRegex := regexp.MustCompile(`\[id: ([0-9]+)\]`)
+	urlRegex := regexp.MustCompile(`\[url: (.+?)\]`)
+	nameRegex := regexp.MustCompile(`^.*?\/(.*?)\s\[`)
+	folderRegex := regexp.MustCompile(`^(.*?)\/`)
+	usernameRegex := regexp.MustCompile(`\[username: (.+?)\]`)
+	passwordRegex := regexp.MustCompile(`.*\] (.*)$`)
+
+	var entries []LastpassEntry
+	trimmedOutput := strings.TrimSuffix(fullOutput, "\n")
+	if trimmedOutput == "" {
+		return []LastpassEntry{}, nil
+	}
+
+	for _, l := range strings.Split(trimmedOutput, "\n") {
+		if l == "" {
+			continue
+		}
+
+		id := util.RegexSearch(idRegex, l)
+		name := util.RegexSearch(nameRegex, l)
+		folder := util.RegexSearch(folderRegex, l)
+		url := util.RegexSearch(urlRegex, l)
+		username := util.RegexSearch(usernameRegex, l)
+		password := util.RegexSearch(passwordRegex, l)
+
+		if id == "" {
+			// Skip entries without an ID
+			continue
+		}
+
+		if url == "http://group" {
+			// Skip entries with a URL of "http://group"
+			continue
+		}
+
+		if !fuzzy && query != "" {
+			searchableString := fmt.Sprintf("%s %s %s %s %s", id, name, folder, url, username)
+			if !util.HasAll(strings.ToLower(searchableString), strings.Split(strings.ToLower(query), " ")) {
+				continue
+			}
+		}
+
+		entries = append(entries, LastpassEntry{
+			ID:       id,
+			Name:     name,
+			Folder:   folder,
+			URL:      url,
+			Username: username,
+			Password: password,
+		})
+	}
+
+	return entries, nil
 }
 
+// GetDetails retrieves detailed information for a specific LastPass item.
 func (ls *LastpassService) GetDetails(itemID string) ([]string, map[string]string, error) {
-    if len(itemID) == 0 {
-        return nil, nil, errors.New("itemID is empty")
-    }
+	if len(itemID) == 0 {
+		return nil, nil, errors.New("itemID is empty")
+	}
 
-    cmd := exec.Command(ls.BinPath, "show", itemID, "--sync=no")
-    out, err := cmd.Output()
+	cmd := ls.ExecCommand(ls.BinPath, "show", itemID, "--sync=no")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, nil, fmt.Errorf("error running lpass show for itemID '%s': %w", itemID, err)
+	}
 
-    if err != nil {
-        return nil, nil, err
-    }
+	keyRegex := regexp.MustCompile(`^(\S.+?):`)
+	valRegex := regexp.MustCompile(`^\S.+?: (.*)`)
+	keys := []string{}
+	details := make(map[string]string)
 
-    keyRegex := regexp.MustCompile(`^(\S.+?):`)
-    valRegex := regexp.MustCompile(`^\S.+?: (.*)`)
-    keys := []string{}
-    details := make(map[string]string)
-    for i, l := range strings.Split(string(out), "\n") {
-        if i == 0 {
-            continue
-        }
-        key := util.RegexSearch(keyRegex, l)
-        val := util.RegexSearch(valRegex, l)
-        keys = append(keys, key)
-        details[key] = val
+	outputLines := strings.Split(strings.TrimSuffix(string(out), "\n"), "\n")
 
-        if key == "Notes" {
-            break
-        }
-    }
-    return keys, details, nil
+	for i, l := range outputLines {
+		if l == "" {
+			continue
+		}
+		if i == 0 {
+			continue
+		}
+		key := util.RegexSearch(keyRegex, l)
+		val := util.RegexSearch(valRegex, l)
+
+		keys = append(keys, key)
+		details[key] = val
+
+		if key == "Notes" {
+			break
+		}
+	}
+	return keys, details, nil
 }
 
-
+// CheckValidity checks if an action can be performed on an entry.
 func (ls *LastpassService) CheckValidity(entry LastpassEntry, action string) bool {
-    if action == "Copy Password" && entry.Password == "" {
-        return false
-    } else if action == "Copy Username" && entry.Username == "" {
-        return false
-    }
-    return true
+	if action == "Copy Password" && entry.Password == "" {
+		return false
+	} else if action == "Copy Username" && entry.Username == "" {
+		return false
+	}
+	return true
 }

--- a/src/pkg/lastpass/lastpass_test.go
+++ b/src/pkg/lastpass/lastpass_test.go
@@ -1,0 +1,508 @@
+package lastpass
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestHelperProcess isn't a real test. It's used as a helper process
+// to simulate the `lpass` binary.
+// It's invoked by tests that replace `ExecCommand`.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	mockExitCode := os.Getenv("MOCK_EXIT_CODE")
+	mockStdout := os.Getenv("MOCK_STDOUT")
+	mockStderr := os.Getenv("MOCK_STDERR")
+
+	if mockStdout != "" {
+		fmt.Fprint(os.Stdout, mockStdout)
+	}
+	if mockStderr != "" {
+		fmt.Fprint(os.Stderr, mockStderr)
+	}
+
+	if mockExitCode == "0" {
+		os.Exit(0)
+	} else {
+		exitCode := 1
+		if parsedCode, err := fmt.Sscan(mockExitCode, &exitCode); err != nil || parsedCode != 1 {
+		}
+		os.Exit(exitCode)
+	}
+}
+
+// mockExecCommand returns a function that, when called, returns an *exec.Cmd
+// configured to run TestHelperProcess. It sets environment variables to control
+// TestHelperProcess's behavior.
+func mockExecCommand(t *testing.T, stdoutData string, stderrData string, exitCode int) func(string, ...string) *exec.Cmd {
+	t.Helper()
+	return func(cmdPath string, args ...string) *exec.Cmd {
+		cs := []string{"-test.run=TestHelperProcess", "--", cmdPath}
+		cs = append(cs, args...)
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = []string{
+			"GO_WANT_HELPER_PROCESS=1",
+			fmt.Sprintf("MOCK_STDOUT=%s", stdoutData),
+			fmt.Sprintf("MOCK_STDERR=%s", stderrData),
+			fmt.Sprintf("MOCK_EXIT_CODE=%d", exitCode),
+		}
+		return cmd
+	}
+}
+
+func TestLastpassServiceIsLoggedIn(t *testing.T) {
+	testCases := []struct {
+		name         string
+		mockCmdName  string
+		mockCmdArgs  string
+		mockStdout   string
+		mockStderr   string
+		mockExitCode int
+		binPath      string
+		wantLoggedIn bool
+	}{
+		{
+			name:         "Logged In",
+			mockCmdName:  "lpass",
+			mockCmdArgs:  "status --quiet",
+			mockStdout:   "",
+			mockStderr:   "",
+			mockExitCode: 0,
+			binPath:      "lpass",
+			wantLoggedIn: true,
+		},
+		{
+			name:         "Not Logged In",
+			mockCmdName:  "lpass",
+			mockCmdArgs:  "status --quiet",
+			mockStdout:   "",
+			mockStderr:   "Not logged in",
+			mockExitCode: 1,
+			binPath:      "lpass",
+			wantLoggedIn: false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ls := &LastpassService{
+				BinPath:     tt.binPath,
+				ExecCommand: mockExecCommand(t, tt.mockStdout, tt.mockStderr, tt.mockExitCode),
+			}
+			if got := ls.IsLoggedIn(); got != tt.wantLoggedIn {
+				t.Errorf("IsLoggedIn() = %v, want %v", got, tt.wantLoggedIn)
+			}
+		})
+	}
+}
+
+func TestLastpassServiceGetFolders(t *testing.T) {
+	testCases := []struct {
+		name            string
+		mockStdout      string
+		mockStderr      string
+		mockExitCode    int
+		wantFolders     []LastpassFolder
+		wantErr         bool
+		expectedErrText string
+	}{
+		{
+			name:         "No folders",
+			mockStdout:   "",
+			mockStderr:   "",
+			mockExitCode: 0,
+			wantFolders:  []LastpassFolder{},
+			wantErr:      false,
+		},
+		{
+			name:         "Single folder",
+			mockStdout:   "Work/\n",
+			mockStderr:   "",
+			mockExitCode: 0,
+			wantFolders: []LastpassFolder{
+				{Name: "Work/"},
+			},
+			wantErr: false,
+		},
+		{
+			name:         "Multiple folders",
+			mockStdout:   "Personal/\nShared-Family/\nWork/\n",
+			mockStderr:   "",
+			mockExitCode: 0,
+			wantFolders: []LastpassFolder{
+				{Name: "Personal/"},
+				{Name: "Shared-Family/"},
+				{Name: "Work/"},
+			},
+			wantErr: false,
+		},
+		{
+			name:         "Folders with spaces and special characters",
+			mockStdout:   "Finance/Banking/\nOld Projects/\nWork Items (New)/\n",
+			mockStderr:   "",
+			mockExitCode: 0,
+			wantFolders: []LastpassFolder{
+				{Name: "Finance/Banking/"},
+				{Name: "Old Projects/"},
+				{Name: "Work Items (New)/"},
+			},
+			wantErr: false,
+		},
+		{
+			name:         "Output with trailing newline already handled by TrimSuffix",
+			mockStdout:   "Folder1/\nFolder2/\n",
+			mockStderr:   "",
+			mockExitCode: 0,
+			wantFolders: []LastpassFolder{
+				{Name: "Folder1/"},
+				{Name: "Folder2/"},
+			},
+			wantErr: false,
+		},
+		{
+			name:            "lpass command fails",
+			mockStdout:      "",
+			mockStderr:      "lpass command not found",
+			mockExitCode:    127,
+			wantFolders:     nil,
+			wantErr:         true,
+			expectedErrText: "error running command to get folders",
+		},
+		{
+			name:            "lpass ls returns error output",
+			mockStdout:      "",
+			mockStderr:      "Error: Not logged in to LastPass.",
+			mockExitCode:    1,
+			wantFolders:     nil,
+			wantErr:         true,
+			expectedErrText: "error running command to get folders",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ls := &LastpassService{
+				BinPath:     "lpass",
+				ExecCommand: mockExecCommand(t, tt.mockStdout, tt.mockStderr, tt.mockExitCode),
+			}
+
+			gotFolders, err := ls.GetFolders()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetFolders() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if tt.expectedErrText != "" && (err == nil || !strings.Contains(err.Error(), tt.expectedErrText)) {
+					t.Errorf("GetFolders() error = %v, want error containing %q", err, tt.expectedErrText)
+				}
+				if !reflect.DeepEqual(gotFolders, tt.wantFolders) {
+					t.Errorf("GetFolders() gotFolders = %v, want %v (on error path)", gotFolders, tt.wantFolders)
+				}
+				return
+			}
+
+			if !reflect.DeepEqual(gotFolders, tt.wantFolders) {
+				t.Errorf("GetFolders() gotFolders = %v, want %v", gotFolders, tt.wantFolders)
+			}
+		})
+	}
+}
+
+func TestLastpassServiceGetEntries(t *testing.T) {
+	type fields struct {
+		BinPath string
+	}
+	type args struct {
+		query   string
+		folders []string
+		fuzzy   bool
+	}
+	testCases := []struct {
+		name            string
+		fields          fields
+		args            args
+		mockStdout      string
+		mockStderr      string
+		mockExitCode    int
+		want            []LastpassEntry
+		wantErr         bool
+		expectedErrText string
+	}{
+		{
+			name: "Test with empty query and folders - no entries",
+			fields: fields{
+				BinPath: "lpass",
+			},
+			args: args{
+				query:   "",
+				folders: []string{},
+				fuzzy:   false,
+			},
+			mockStdout:   "",
+			mockStderr:   "",
+			mockExitCode: 0,
+			want:         []LastpassEntry{},
+			wantErr:      false,
+		},
+		{
+			name: "One entry, no query, default folder",
+			fields: fields{
+				BinPath: "lpass",
+			},
+			args: args{
+				query:   "",
+				folders: []string{},
+				fuzzy:   false,
+			},
+			mockStdout:   "Work/My Entry [id: 123] [url: http://example.com] [username: user1] pass1\n",
+			mockStderr:   "",
+			mockExitCode: 0,
+			want: []LastpassEntry{
+				{ID: "123", Name: "My Entry", Folder: "Work", URL: "http://example.com", Username: "user1", Password: "pass1"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Two entries, query matches one",
+			fields: fields{
+				BinPath: "lpass",
+			},
+			args: args{
+				query:   "ServiceA",
+				folders: []string{},
+				fuzzy:   false,
+			},
+			mockStdout: "Dev/ServiceA [id: 100] [url: http://service-a.com] [username: dev_a] pass_a\n" +
+				"Prod/ServiceB [id: 101] [url: http://service-b.com] [username: prod_b] pass_b\n",
+			mockStderr:   "",
+			mockExitCode: 0,
+			want: []LastpassEntry{
+				{ID: "100", Name: "ServiceA", Folder: "Dev", URL: "http://service-a.com", Username: "dev_a", Password: "pass_a"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Specific folder, one entry",
+			fields: fields{
+				BinPath: "lpass",
+			},
+			args: args{
+				query:   "",
+				folders: []string{"Social"},
+				fuzzy:   false,
+			},
+			mockStdout:   "Social/Twitter [id: 789] [url: http://twitter.com] [username: mytwitter] twpass\n",
+			mockStderr:   "",
+			mockExitCode: 0,
+			want: []LastpassEntry{
+				{ID: "789", Name: "Twitter", Folder: "Social", URL: "http://twitter.com", Username: "mytwitter", Password: "twpass"},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ls := &LastpassService{
+				BinPath: tt.fields.BinPath,
+				// The mockExecCommand needs to be smart enough to handle the folder argument
+				// that GetEntries appends to the command.
+				// The `expectedCmdArgs` in mockExecCommand should be the *base* command.
+				// TestHelperProcess will receive the full command including the folder.
+				ExecCommand: mockExecCommand(t, tt.mockStdout, tt.mockStderr, tt.mockExitCode),
+			}
+			got, err := ls.GetEntries(tt.args.query, tt.args.folders, tt.args.fuzzy)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetEntries() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if tt.expectedErrText != "" && (err == nil || !strings.Contains(err.Error(), tt.expectedErrText)) {
+					t.Errorf("GetEntries() error = %v, want error containing %v", err, tt.expectedErrText)
+				}
+				// If error is expected, we might not need to check `got` further, or check if it's nil/empty
+				if !reflect.DeepEqual(got, tt.want) { // tt.want should be nil or empty for error cases
+					t.Errorf("GetEntries() got = %v, want %v (on error path)", got, tt.want)
+				}
+				return // Important to return after handling error case
+			}
+
+			// If no error was wanted, proceed with deep equal check
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetEntries() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLastpassServiceGetDetails(t *testing.T) {
+	testCases := []struct {
+		name            string
+		itemID          string
+		mockStdout      string
+		mockStderr      string
+		mockExitCode    int
+		wantKeys        []string
+		wantDetails     map[string]string
+		wantErr         bool
+		expectedErrText string
+	}{
+		{
+			name:   "Successful retrieval",
+			itemID: "12345",
+			mockStdout: `SiteNameOrPath [id: 12345]
+Username: user@example.com
+Password: securepassword
+URL: https://example.com
+Notes: This is a note.
+More notes on next line, but will be missed by current parser.
+Last Modified: Thu Jan 01 00:00:00 UTC 1970
+`,
+			mockStderr:   "",
+			mockExitCode: 0,
+			wantKeys: []string{
+				"Username",
+				"Password",
+				"URL",
+				"Notes",
+			},
+			wantDetails: map[string]string{
+				"Username": "user@example.com",
+				"Password": "securepassword",
+				"URL":      "https://example.com",
+				"Notes":    "This is a note.",
+			},
+			wantErr: false,
+		},
+		{
+			name:            "Item not found - command error",
+			itemID:          "nonexistent",
+			mockStdout:      "",
+			mockStderr:      "Error: Could not find item 'nonexistent'",
+			mockExitCode:    1,
+			wantKeys:        nil,
+			wantDetails:     nil,
+			wantErr:         true,
+			expectedErrText: "error running lpass show for itemID 'nonexistent'",
+		},
+		{
+			name:            "Empty itemID",
+			itemID:          "",
+			mockStdout:      "", // Command won't be called
+			mockStderr:      "",
+			mockExitCode:    0,
+			wantKeys:        nil,
+			wantDetails:     nil,
+			wantErr:         true,
+			expectedErrText: "itemID is empty",
+		},
+		{
+			name:         "Only header line from lpass",
+			itemID:       "67890",
+			mockStdout:   "OnlyHeader [id: 67890]\n",
+			mockStderr:   "",
+			mockExitCode: 0,
+			wantKeys:     []string{},
+			wantDetails:  map[string]string{},
+			wantErr:      false,
+		},
+		{
+			name:   "No notes field, parsing completes",
+			itemID: "11223",
+			mockStdout: `AnotherSite [id: 11223]
+URL: http://anothersite.com
+Username: anotheruser
+`, // No "Notes:" field
+			mockStderr:   "",
+			mockExitCode: 0,
+			wantKeys: []string{
+				"URL",
+				"Username",
+			},
+			wantDetails: map[string]string{
+				"URL":      "http://anothersite.com",
+				"Username": "anotheruser",
+			},
+			wantErr: false,
+		},
+		{
+			name:   "Field with empty value",
+			itemID: "33445",
+			mockStdout: `ItemWithEmptyField [id: 33445]
+URL: http://site.com
+CustomField: 
+Notes: Some notes.
+`,
+			mockStderr:   "",
+			mockExitCode: 0,
+			wantKeys: []string{
+				"URL",
+				"CustomField",
+				"Notes",
+			},
+			wantDetails: map[string]string{
+				"URL":         "http://site.com",
+				"CustomField": "",
+				"Notes":       "Some notes.",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.itemID == "" && tt.wantErr && tt.expectedErrText == "itemID is empty" {
+				ls := &LastpassService{BinPath: "lpass"}
+				_, _, err := ls.GetDetails(tt.itemID)
+				if err == nil {
+					t.Fatalf("GetDetails() with empty itemID expected an error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.expectedErrText) {
+					t.Errorf("GetDetails() with empty itemID error = %v, want error containing %q", err, tt.expectedErrText)
+				}
+				return
+			}
+
+			ls := &LastpassService{
+				BinPath:     "lpass",
+				ExecCommand: mockExecCommand(t, tt.mockStdout, tt.mockStderr, tt.mockExitCode),
+			}
+
+			gotKeys, gotDetails, err := ls.GetDetails(tt.itemID)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetDetails() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				if tt.expectedErrText != "" && (err == nil || !strings.Contains(err.Error(), tt.expectedErrText)) {
+					t.Errorf("GetDetails() error = %v, want error containing %q", err, tt.expectedErrText)
+				}
+				if !reflect.DeepEqual(gotKeys, tt.wantKeys) {
+					t.Errorf("GetDetails() gotKeys = %v, want %v (on error path)", gotKeys, tt.wantKeys)
+				}
+				if !reflect.DeepEqual(gotDetails, tt.wantDetails) {
+					t.Errorf("GetDetails() gotDetails = %v, want %v (on error path)", gotDetails, tt.wantDetails)
+				}
+				return
+			}
+
+			if !reflect.DeepEqual(gotKeys, tt.wantKeys) {
+				t.Errorf("GetDetails() gotKeys = %v, want %v", gotKeys, tt.wantKeys)
+			}
+			if !reflect.DeepEqual(gotDetails, tt.wantDetails) {
+				t.Errorf("GetDetails() gotDetails = %v, want %v", gotDetails, tt.wantDetails)
+			}
+		})
+	}
+}

--- a/src/pkg/lastpass/lastpass_test.go
+++ b/src/pkg/lastpass/lastpass_test.go
@@ -23,10 +23,10 @@ func TestHelperProcess(t *testing.T) {
 	mockStderr := os.Getenv("MOCK_STDERR")
 
 	if mockStdout != "" {
-		fmt.Fprint(os.Stdout, mockStdout)
+		_, _ = fmt.Fprint(os.Stdout, mockStdout)
 	}
 	if mockStderr != "" {
-		fmt.Fprint(os.Stderr, mockStderr)
+		_, _ = fmt.Fprint(os.Stderr, mockStderr)
 	}
 
 	if mockExitCode == "0" {
@@ -93,7 +93,7 @@ func TestLastpassServiceIsLoggedIn(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			ls := &LastpassService{
+			ls := &Service{
 				BinPath:     tt.binPath,
 				ExecCommand: mockExecCommand(t, tt.mockStdout, tt.mockStderr, tt.mockExitCode),
 			}
@@ -110,7 +110,7 @@ func TestLastpassServiceGetFolders(t *testing.T) {
 		mockStdout      string
 		mockStderr      string
 		mockExitCode    int
-		wantFolders     []LastpassFolder
+		wantFolders     []Folder
 		wantErr         bool
 		expectedErrText string
 	}{
@@ -119,7 +119,7 @@ func TestLastpassServiceGetFolders(t *testing.T) {
 			mockStdout:   "",
 			mockStderr:   "",
 			mockExitCode: 0,
-			wantFolders:  []LastpassFolder{},
+			wantFolders:  []Folder{},
 			wantErr:      false,
 		},
 		{
@@ -127,7 +127,7 @@ func TestLastpassServiceGetFolders(t *testing.T) {
 			mockStdout:   "Work/\n",
 			mockStderr:   "",
 			mockExitCode: 0,
-			wantFolders: []LastpassFolder{
+			wantFolders: []Folder{
 				{Name: "Work/"},
 			},
 			wantErr: false,
@@ -137,7 +137,7 @@ func TestLastpassServiceGetFolders(t *testing.T) {
 			mockStdout:   "Personal/\nShared-Family/\nWork/\n",
 			mockStderr:   "",
 			mockExitCode: 0,
-			wantFolders: []LastpassFolder{
+			wantFolders: []Folder{
 				{Name: "Personal/"},
 				{Name: "Shared-Family/"},
 				{Name: "Work/"},
@@ -149,7 +149,7 @@ func TestLastpassServiceGetFolders(t *testing.T) {
 			mockStdout:   "Finance/Banking/\nOld Projects/\nWork Items (New)/\n",
 			mockStderr:   "",
 			mockExitCode: 0,
-			wantFolders: []LastpassFolder{
+			wantFolders: []Folder{
 				{Name: "Finance/Banking/"},
 				{Name: "Old Projects/"},
 				{Name: "Work Items (New)/"},
@@ -161,7 +161,7 @@ func TestLastpassServiceGetFolders(t *testing.T) {
 			mockStdout:   "Folder1/\nFolder2/\n",
 			mockStderr:   "",
 			mockExitCode: 0,
-			wantFolders: []LastpassFolder{
+			wantFolders: []Folder{
 				{Name: "Folder1/"},
 				{Name: "Folder2/"},
 			},
@@ -189,7 +189,7 @@ func TestLastpassServiceGetFolders(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			ls := &LastpassService{
+			ls := &Service{
 				BinPath:     "lpass",
 				ExecCommand: mockExecCommand(t, tt.mockStdout, tt.mockStderr, tt.mockExitCode),
 			}
@@ -233,7 +233,7 @@ func TestLastpassServiceGetEntries(t *testing.T) {
 		mockStdout      string
 		mockStderr      string
 		mockExitCode    int
-		want            []LastpassEntry
+		want            []Entry
 		wantErr         bool
 		expectedErrText string
 	}{
@@ -250,7 +250,7 @@ func TestLastpassServiceGetEntries(t *testing.T) {
 			mockStdout:   "",
 			mockStderr:   "",
 			mockExitCode: 0,
-			want:         []LastpassEntry{},
+			want:         []Entry{},
 			wantErr:      false,
 		},
 		{
@@ -266,7 +266,7 @@ func TestLastpassServiceGetEntries(t *testing.T) {
 			mockStdout:   "Work/My Entry [id: 123] [url: http://example.com] [username: user1] pass1\n",
 			mockStderr:   "",
 			mockExitCode: 0,
-			want: []LastpassEntry{
+			want: []Entry{
 				{ID: "123", Name: "My Entry", Folder: "Work", URL: "http://example.com", Username: "user1", Password: "pass1"},
 			},
 			wantErr: false,
@@ -285,7 +285,7 @@ func TestLastpassServiceGetEntries(t *testing.T) {
 				"Prod/ServiceB [id: 101] [url: http://service-b.com] [username: prod_b] pass_b\n",
 			mockStderr:   "",
 			mockExitCode: 0,
-			want: []LastpassEntry{
+			want: []Entry{
 				{ID: "100", Name: "ServiceA", Folder: "Dev", URL: "http://service-a.com", Username: "dev_a", Password: "pass_a"},
 			},
 			wantErr: false,
@@ -303,7 +303,7 @@ func TestLastpassServiceGetEntries(t *testing.T) {
 			mockStdout:   "Social/Twitter [id: 789] [url: http://twitter.com] [username: mytwitter] twpass\n",
 			mockStderr:   "",
 			mockExitCode: 0,
-			want: []LastpassEntry{
+			want: []Entry{
 				{ID: "789", Name: "Twitter", Folder: "Social", URL: "http://twitter.com", Username: "mytwitter", Password: "twpass"},
 			},
 			wantErr: false,
@@ -311,7 +311,7 @@ func TestLastpassServiceGetEntries(t *testing.T) {
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			ls := &LastpassService{
+			ls := &Service{
 				BinPath: tt.fields.BinPath,
 				// The mockExecCommand needs to be smart enough to handle the folder argument
 				// that GetEntries appends to the command.
@@ -439,7 +439,7 @@ Username: anotheruser
 			itemID: "33445",
 			mockStdout: `ItemWithEmptyField [id: 33445]
 URL: http://site.com
-CustomField: 
+CustomField:
 Notes: Some notes.
 `,
 			mockStderr:   "",
@@ -461,7 +461,7 @@ Notes: Some notes.
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.itemID == "" && tt.wantErr && tt.expectedErrText == "itemID is empty" {
-				ls := &LastpassService{BinPath: "lpass"}
+				ls := &Service{BinPath: "lpass"}
 				_, _, err := ls.GetDetails(tt.itemID)
 				if err == nil {
 					t.Fatalf("GetDetails() with empty itemID expected an error, got nil")
@@ -472,7 +472,7 @@ Notes: Some notes.
 				return
 			}
 
-			ls := &LastpassService{
+			ls := &Service{
 				BinPath:     "lpass",
 				ExecCommand: mockExecCommand(t, tt.mockStdout, tt.mockStderr, tt.mockExitCode),
 			}

--- a/src/pkg/lastpass/lastpass_test.go
+++ b/src/pkg/lastpass/lastpass_test.go
@@ -34,6 +34,8 @@ func TestHelperProcess(t *testing.T) {
 	} else {
 		exitCode := 1
 		if parsedCode, err := fmt.Sscan(mockExitCode, &exitCode); err != nil || parsedCode != 1 {
+			t.Errorf("TestHelperProcess: failed to parse MOCK_EXIT_CODE %q: %v", mockExitCode, err)
+			exitCode = 1
 		}
 		os.Exit(exitCode)
 	}

--- a/src/pkg/util/util.go
+++ b/src/pkg/util/util.go
@@ -22,9 +22,8 @@ var (
 func RegexSearch(regex *regexp.Regexp, query string) string {
 	if regex.MatchString(query) {
 		return regex.FindStringSubmatch(query)[1]
-	} else {
-		return ""
 	}
+	return ""
 }
 
 func HasAll(input string, words []string) bool {
@@ -37,7 +36,7 @@ func HasAll(input string, words []string) bool {
 	return true
 }
 
-func GeneratePassword(length int, symbols bool, allowedSymbols string) (string, error) {
+func GeneratePassword(length int, symbols bool, allowedSymbols string) (string, error) { //nolint:revive // Allow control flag for symbols
 	input := password.GeneratorInput{
 		Symbols: allowedSymbols,
 	}
@@ -66,7 +65,7 @@ func GetIcon(key string) *aw.Icon {
 
 	if os.IsNotExist(err) {
 		return &aw.Icon{Value: "icons/default.png"}
-	} else {
-		return &aw.Icon{Value: iconPath}
 	}
+
+	return &aw.Icon{Value: iconPath}
 }

--- a/src/pkg/util/util.go
+++ b/src/pkg/util/util.go
@@ -11,63 +11,62 @@ import (
 )
 
 var (
-    IconFolder = &aw.Icon{Value: "icons/group.png"}
-    IconBack   = &aw.Icon{Value: "icons/go_back.png"}
-    IconSN     = &aw.Icon{Value: "icons/sn.png"}
-    IconPW     = &aw.Icon{Value: "icons/password-alt.png"}
-    IconDelete = &aw.Icon{Value: "icons/trash.png"}
-    IconEdit   = &aw.Icon{Value: "icons/edit.png"}
+	IconFolder = &aw.Icon{Value: "icons/group.png"}
+	IconBack   = &aw.Icon{Value: "icons/go_back.png"}
+	IconSN     = &aw.Icon{Value: "icons/sn.png"}
+	IconPW     = &aw.Icon{Value: "icons/password-alt.png"}
+	IconDelete = &aw.Icon{Value: "icons/trash.png"}
+	IconEdit   = &aw.Icon{Value: "icons/edit.png"}
 )
 
-
 func RegexSearch(regex *regexp.Regexp, query string) string {
-    if regex.MatchString(query) {
-        return regex.FindStringSubmatch(query)[1]
-    } else {
-        return ""
-    }
+	if regex.MatchString(query) {
+		return regex.FindStringSubmatch(query)[1]
+	} else {
+		return ""
+	}
 }
 
 func HasAll(input string, words []string) bool {
-    for _, w := range words {
-        if strings.Contains(input, w) {
-            continue
-        }
-        return false
-    }
-    return true
+	for _, w := range words {
+		if strings.Contains(input, w) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func GeneratePassword(length int, symbols bool, allowedSymbols string) (string, error) {
-    input := password.GeneratorInput{
-        Symbols: allowedSymbols,
-    }
+	input := password.GeneratorInput{
+		Symbols: allowedSymbols,
+	}
 
-    sc := 0
-    if symbols {
-        sc = length / 4
-    }
+	sc := 0
+	if symbols {
+		sc = length / 4
+	}
 
-    gen, err := password.NewGenerator(&input)
-    if err != nil {
-        return "", err
-    }
+	gen, err := password.NewGenerator(&input)
+	if err != nil {
+		return "", err
+	}
 
-    pw, err := gen.Generate(length, length/4, sc, false, true)
-    if err != nil {
-        return "", err
-    }
+	pw, err := gen.Generate(length, length/4, sc, false, true)
+	if err != nil {
+		return "", err
+	}
 
-    return pw, nil
+	return pw, nil
 }
 
 func GetIcon(key string) *aw.Icon {
-    iconPath := fmt.Sprintf("icons/%s.png", strings.ToLower(key))
-    _, err := os.Stat(iconPath)
+	iconPath := fmt.Sprintf("icons/%s.png", strings.ToLower(key))
+	_, err := os.Stat(iconPath)
 
-    if os.IsNotExist(err) {
-        return &aw.Icon{Value: "icons/default.png"}
-    } else {
-        return &aw.Icon{Value: iconPath}
-    }
+	if os.IsNotExist(err) {
+		return &aw.Icon{Value: "icons/default.png"}
+	} else {
+		return &aw.Icon{Value: iconPath}
+	}
 }


### PR DESCRIPTION
This PR enhances the LastpassService by refactoring for testability, introducing  unit tests, applying gofumpt formatting, and crucially, fixing the logic for correctly retrieving LastPass folders.

**Key Changes:**

**Corrected Folder Retrieval `(src/pkg/lastpass/lastpass.go)`:**

GetFolders: Updated the lpass ls command format to %/as%/ag and improved output parsing to ensure folders are returned accurately.

**Refactored for Testability `(src/pkg/lastpass/lastpass.go)`:**

Added ExecCommand field to LastpassService to enable mocking of lpass CLI calls for isolated unit testing.

Added Unit Tests (src/pkg/lastpass/lastpass_test.go):

Created tests for IsLoggedIn, GetFolders, GetEntries, and GetDetails using a mock lpass CLI environment.

**Code Formatting:**

Applied `gofumpt` to the codebase, resulting in numerous stylistic changes for consistency.